### PR TITLE
[v2] Remove spamful total pkmn caught display

### DIFF
--- a/cogs/modules/pokemon_functionality.py
+++ b/cogs/modules/pokemon_functionality.py
@@ -63,7 +63,6 @@ class PokemonFunctionality:
         self.trainer_data = self._load_trainer_file()
         self._save_trainer_file(self.trainer_data, backup=True)
         self.bot.loop.create_task(self._update_cache())
-        self.bot.loop.create_task(self._display_total_pokemon_caught())
         self.bot.loop.create_task(self._load_event())
         self.bot.loop.create_task(self._refresh_daily())
 


### PR DESCRIPTION
This PR removes the create task loop for displaying the pokemon caught display. This has been potential harm to spam the discord API for displaying the pokemon caught time and can be improved upon to display the pokemon count during the upcoming bot refactor.